### PR TITLE
Rename ManagerRefresh to InventoryRefresh

### DIFF
--- a/app/models/manageiq/providers/dummy_provider/builder.rb
+++ b/app/models/manageiq/providers/dummy_provider/builder.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::DummyProvider::Builder
   class << self
     def build_inventory(ems, target)
       case target
-      when ManagerRefresh::TargetCollection
+      when InventoryRefresh::TargetCollection
         targeted_inventory(ems, target)
       else
         cloud_manager_inventory(ems, target)


### PR DESCRIPTION
Rename ManagerRefresh to InventoryRefresh

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/17965