### PR TITLE
Remove duplicated persister shared_options

### DIFF
--- a/app/models/manageiq/providers/dummy_provider/inventory/persister/cloud_manager.rb
+++ b/app/models/manageiq/providers/dummy_provider/inventory/persister/cloud_manager.rb
@@ -3,14 +3,4 @@ class ManageIQ::Providers::DummyProvider::Inventory::Persister::CloudManager < M
     add_collection(cloud, :vms)
     add_collection(cloud, :flavors)
   end
-
-  def parent
-    manager.presence
-  end
-
-  def shared_options
-    {
-      :parent => parent
-    }
-  end
 end


### PR DESCRIPTION
The shared_options were duplicated from the base persister