### PR TITLE
cleanup .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
-dist: xenial
 language: ruby
 rvm:
 - 2.5.7
 - 2.6.5
-sudo: false
 cache: bundler
 env:
   global:


### PR DESCRIPTION
per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration: `If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon...` and listing the distro on this repo isn’t necessary and Jason says we should only do so when it’s required 