### PR TITLE
nix deprecated codeclimate-test-reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,9 @@ env:
 addons:
   postgresql: '10'
 install: bin/setup
-after_script: bundle exec codeclimate-test-reporter
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+after_script:
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/manageiq-providers-dummy_provider.gemspec
+++ b/manageiq-providers-dummy_provider.gemspec
@@ -13,6 +13,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
```
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

it depends on the addition of the token re: https://github.com/ManageIQ/azure-armrest/pull/403#issuecomment-754050779

@miq-bot add_label dependencies, test 
@miq-bot assign @Fryguy 