### PR TITLE
Adjust empty/initial values for select fields in DDF schemas

### DIFF
--- a/app/models/manageiq/providers/dummy_provider/cloud_manager.rb
+++ b/app/models/manageiq/providers/dummy_provider/cloud_manager.rb
@@ -39,12 +39,13 @@ class ManageIQ::Providers::DummyProvider::CloudManager < ManageIQ::Providers::Cl
               :validationDependencies => %w[type provider_region],
               :fields                 => [
                 {
-                  :component  => "select",
-                  :name       => "endpoints.default.security_protocol",
-                  :label      => _("Security Protocol"),
-                  :isRequired => true,
-                  :validate   => [{:type => "required"}],
-                  :options    => [
+                  :component    => "select",
+                  :name         => "endpoints.default.security_protocol",
+                  :label        => _("Security Protocol"),
+                  :isRequired   => true,
+                  :initialValue => 'ssl-with-validation',
+                  :validate     => [{:type => "required"}],
+                  :options      => [
                     {
                       :label => _("SSL without validation"),
                       :value => "ssl-no-validation"


### PR DESCRIPTION
Because carbon has four different dropdowns, the DDF schemas need to have explicit initialValue or includeEmpty settings in order to make the form validation work.

@miq-bot assign @agrare