### PR TITLE
Remove an old gettext initializer that's unused

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ_Providers_DummyProvider',
-  ManageIQ::Providers::DummyProvider::Engine.root.join('locale').to_s,
-  :po
-)


### PR DESCRIPTION
Other providers don't have this so I think we can remove it.

Note, this is not compatible with rails 7.  We'd have to either require the file before using the constant or possibly do this in an after_initialize block or somehow tell it to autoload this once.  Rails 7 doesn't want to autoload in initializers because they're not reloaded when the application code is reloaded.

EDIT: Note, this should make master branch 💚 💚 💚 

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
