### PR TITLE
Add ruby 3.1 to the test matrix and use it for code coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         ruby-version:
         - '3.0'
+        - '3.1'
     services:
       postgres:
         image: manageiq/postgresql:13
@@ -43,6 +44,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: "${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' }}"
+      if: "${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.1' }}"
       continue-on-error: true
       uses: paambaati/codeclimate-action@v8

--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ_Providers_DummyProvider',
-  ManageIQ::Providers::DummyProvider::Engine.root.join('locale').to_s,
-  :po
-)


### PR DESCRIPTION
Built on top of #62 

Merge after:

- [x] https://github.com/ManageIQ/manageiq-providers-dummy_provider/pull/62 (it's built on top of it so it can go 💚 💚 💚 )