### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/dummy_provider/cloud_manager.rb
+++ b/app/models/manageiq/providers/dummy_provider/cloud_manager.rb
@@ -1,11 +1,4 @@
 class ManageIQ::Providers::DummyProvider::CloudManager < ManageIQ::Providers::CloudManager
-  require_nested :Flavor
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :Vm
-
   supports :metrics
 
   # Form schema for creating/editing a provider, it should follow the DDF specification

--- a/app/models/manageiq/providers/dummy_provider/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/dummy_provider/cloud_manager/event_catcher.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::DummyProvider::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/dummy_provider/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/dummy_provider/cloud_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::DummyProvider::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "dummy_provider"
 
   def friendly_name

--- a/app/models/manageiq/providers/dummy_provider/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/dummy_provider/cloud_manager/refresh_worker.rb
@@ -1,8 +1,5 @@
 class ManageIQ::Providers::DummyProvider::CloudManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.ems_class
     parent
   end
-
 end

--- a/app/models/manageiq/providers/dummy_provider/inventory.rb
+++ b/app/models/manageiq/providers/dummy_provider/inventory.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::DummyProvider::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
 end

--- a/app/models/manageiq/providers/dummy_provider/inventory/collector.rb
+++ b/app/models/manageiq/providers/dummy_provider/inventory/collector.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::DummyProvider::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :CloudManager
 end

--- a/app/models/manageiq/providers/dummy_provider/inventory/parser.rb
+++ b/app/models/manageiq/providers/dummy_provider/inventory/parser.rb
@@ -1,5 +1,3 @@
 class ManageIQ::Providers::DummyProvider::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :CloudManager
-
   include Vmdb::Logging
 end

--- a/app/models/manageiq/providers/dummy_provider/inventory/persister.rb
+++ b/app/models/manageiq/providers/dummy_provider/inventory/persister.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::DummyProvider::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :CloudManager
 end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: ManageIQ/manageiq#22854

@jrafanie Please review.